### PR TITLE
Remove resource order re-sort

### DIFF
--- a/ckanext/ord_hierarchy/templates/package/snippets/resources_list.html
+++ b/ckanext/ord_hierarchy/templates/package/snippets/resources_list.html
@@ -40,7 +40,7 @@ Example:
   {% if resources %}
   <h3>{{ _('Data Resources') }}</h3>
     <ul class="resource-list">
-      {% for resource in resources|sort(attribute='name') %}
+      {% for resource in resources %}
         {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource %}
       {% endfor %}
     </ul>


### PR DESCRIPTION
Resolves issue whereby built-in resource reordering would be overridden by this template, because sorting the resources doesn't reflect their order in the pkg_dict.